### PR TITLE
chore(Lifecycle): rename inner unity event to facilitate intellisense

### DIFF
--- a/Runtime/Scripts/Data/Operation/Extraction/ChildTransformExtractor.cs
+++ b/Runtime/Scripts/Data/Operation/Extraction/ChildTransformExtractor.cs
@@ -7,10 +7,10 @@ namespace VRToolkitExtras.Data.Operation.Extraction
     public class ChildTransformExtractor : MonoBehaviour
     {
         [Serializable]
-        public class UnityEvent : UnityEvent<GameObject> { }
+        public class GameObjectUnityEvent : UnityEvent<GameObject> { }
 
         public GameObject Parent;
-        public UnityEvent Extracted;
+        public GameObjectUnityEvent Extracted;
 
         public void DoExtract(GameObject parent)
         {

--- a/Runtime/Scripts/Data/Operation/Extraction/ChildTransformsExtractor.cs
+++ b/Runtime/Scripts/Data/Operation/Extraction/ChildTransformsExtractor.cs
@@ -7,10 +7,10 @@ namespace VRToolkitExtras.Data.Operation.Extraction
     public class ChildTransformsExtractor : MonoBehaviour
     {
         [Serializable]
-        public class UnityEvent : UnityEvent<GameObject> { }
+        public class GameObjectUnityEvent : UnityEvent<GameObject> { }
 
         public GameObject Parent;
-        public UnityEvent Extracted;
+        public GameObjectUnityEvent Extracted;
 
         public void DoExtract(GameObject parent)
         {

--- a/Runtime/Scripts/Data/Operation/Extraction/GrabInteractableExtractor.cs
+++ b/Runtime/Scripts/Data/Operation/Extraction/GrabInteractableExtractor.cs
@@ -8,9 +8,9 @@ namespace VRToolkitExtras.Data.Operation.Extraction
     public class GrabInteractableExtractor : MonoBehaviour
     {
         [Serializable]
-        public class UnityEvent : UnityEvent<GrabInteractableAction> { }
+        public class GrabInteractableActionUnityEvent : UnityEvent<GrabInteractableAction> { }
 
-        public UnityEvent Extracted;
+        public GrabInteractableActionUnityEvent Extracted;
 
         public void DoExtract(GameObject container)
         {

--- a/Runtime/Scripts/Data/Operation/Extraction/MomentsFacadeExtractor.cs
+++ b/Runtime/Scripts/Data/Operation/Extraction/MomentsFacadeExtractor.cs
@@ -1,21 +1,22 @@
 ﻿using System;
 using UnityEngine;
 using UnityEngine.Events;
+using VRToolkitExtras.Prefabs;
 
 namespace VRToolkitExtras.Data.Operation.Extraction
 {
     public class MomentsFacadeExtractor : MonoBehaviour
     {
         [Serializable]
-        public class UnityEvent : UnityEvent<VRToolkitExtras.Prefabs.MomentsFacade> { }
+        public class MomentsFacadeUnityEvent : UnityEvent<MomentsFacade> { }
 
-        public UnityEvent Extracted;
+        public MomentsFacadeUnityEvent Extracted;
 
         public void DoExtract(GameObject target)
         {
             foreach (Transform child in target.transform)
             {
-                var facade = child.GetComponent<VRToolkitExtras.Prefabs.MomentsFacade>();
+                var facade = child.GetComponent<MomentsFacade>();
                 if (facade == null) continue;
 
                 Extracted?.Invoke(facade);

--- a/Runtime/Scripts/Events/Lifecycle/AwakeLifecycleEvent.cs
+++ b/Runtime/Scripts/Events/Lifecycle/AwakeLifecycleEvent.cs
@@ -8,9 +8,9 @@ namespace VRToolkitExtras.Events.Lifecycle
     {
     
         [Serializable]
-        public class UnityEvent : UnityEvent<GameObject> { }
+        public class GameObjectUnityEvent : UnityEvent<GameObject> { }
 
-        public UnityEvent Awaken;
+        public GameObjectUnityEvent Awaken;
 
         private void Awake()
         {


### PR DESCRIPTION
Within the same namespace, just typing UnityEvent and then use intellisense to 
suggest the namespace would prioritize the inner class instead of 
UnityEngine.Event.UnityEvent
Also, stating the argument type help code clarity and consistency in the case of
multiple param types of derived inner UnityEvent needed in a single class